### PR TITLE
Fix tranlsation for 'MeetingExecutive'

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,8 +6,8 @@ The Products.MeetingCommunes version must be the same as the Products.PloneMeeti
 4.1.15 (unreleased)
 -------------------
 
-- Nothing changed yet.
-
+- Fix tranlsation for 'MeetingExecutive'
+  [vpiret]
 
 4.1.14 (2020-06-24)
 -------------------

--- a/src/Products/MeetingCommunes/locales/de/LC_MESSAGES/plone.po
+++ b/src/Products/MeetingCommunes/locales/de/LC_MESSAGES/plone.po
@@ -99,6 +99,10 @@ msgstr "TOP Rat"
 msgid "MeetingItemEM"
 msgstr ""
 
+#. Default: "MeetingItemExecutive"
+msgid "MeetingItemExecutive"
+msgstr ""
+
 #. Default: "MeetingItemNEGO"
 msgid "MeetingItemNEGO"
 msgstr ""
@@ -145,6 +149,10 @@ msgstr ""
 
 #. Default: "Meeting Item Recurring EM"
 msgid "MeetingItemRecurringEM"
+msgstr ""
+
+#. Default: "MeetingItemRecurringExecutive"
+msgid "MeetingItemRecurringExecutive"
 msgstr ""
 
 #. Default: "MeetingItemRecurringNEGO"
@@ -249,6 +257,10 @@ msgstr ""
 
 #. Default: "Meeting Item Template EM"
 msgid "MeetingItemTemplateEM"
+msgstr ""
+
+#. Default: "MeetingItemTemplateExecutive"
+msgid "MeetingItemTemplateExecutive"
 msgstr ""
 
 #. Default: "MeetingItemTemplateNEGO"

--- a/src/Products/MeetingCommunes/locales/de/LC_MESSAGES/plone.po
+++ b/src/Products/MeetingCommunes/locales/de/LC_MESSAGES/plone.po
@@ -55,6 +55,10 @@ msgstr "Sitzung des Gemeinderats"
 msgid "MeetingEM"
 msgstr ""
 
+#. Default: "MeetingExecutive"
+msgid "MeetingExecutive"
+msgstr ""
+
 #. Default: "Meeting Item AG"
 msgid "MeetingItemAG"
 msgstr ""

--- a/src/Products/MeetingCommunes/locales/en/LC_MESSAGES/plone.po
+++ b/src/Products/MeetingCommunes/locales/en/LC_MESSAGES/plone.po
@@ -58,6 +58,10 @@ msgstr "City council meeting"
 msgid "MeetingEM"
 msgstr ""
 
+#. Default: "MeetingExecutive"
+msgid "MeetingExecutive"
+msgstr ""
+
 #. Default: "Meeting Item AG"
 msgid "MeetingItemAG"
 msgstr ""

--- a/src/Products/MeetingCommunes/locales/en/LC_MESSAGES/plone.po
+++ b/src/Products/MeetingCommunes/locales/en/LC_MESSAGES/plone.po
@@ -102,6 +102,10 @@ msgstr "Council item"
 msgid "MeetingItemEM"
 msgstr ""
 
+#. Default: "MeetingItemExecutive"
+msgid "MeetingItemExecutive"
+msgstr ""
+
 #. Default: "MeetingItemNEGO"
 msgid "MeetingItemNEGO"
 msgstr ""
@@ -148,6 +152,10 @@ msgstr ""
 
 #. Default: "Meeting Item Recurring EM"
 msgid "MeetingItemRecurringEM"
+msgstr ""
+
+#. Default: "MeetingItemRecurringExecutive"
+msgid "MeetingItemRecurringExecutive"
 msgstr ""
 
 #. Default: "MeetingItemRecurringNEGO"
@@ -252,6 +260,10 @@ msgstr ""
 
 #. Default: "Meeting Item Template EM"
 msgid "MeetingItemTemplateEM"
+msgstr ""
+
+#. Default: "MeetingItemTemplateExecutive"
+msgid "MeetingItemTemplateExecutive"
 msgstr ""
 
 #. Default: "MeetingItemTemplateNEGO"

--- a/src/Products/MeetingCommunes/locales/es/LC_MESSAGES/plone.po
+++ b/src/Products/MeetingCommunes/locales/es/LC_MESSAGES/plone.po
@@ -58,6 +58,10 @@ msgstr "Reunión del Consejo Comunal"
 msgid "MeetingEM"
 msgstr ""
 
+#. Default: "MeetingExecutive"
+msgid "MeetingExecutive"
+msgstr ""
+
 #. Default: "Meeting Item AG"
 msgid "MeetingItemAG"
 msgstr ""

--- a/src/Products/MeetingCommunes/locales/es/LC_MESSAGES/plone.po
+++ b/src/Products/MeetingCommunes/locales/es/LC_MESSAGES/plone.po
@@ -102,6 +102,10 @@ msgstr "Tema Consejo"
 msgid "MeetingItemEM"
 msgstr ""
 
+#. Default: "MeetingItemExecutive"
+msgid "MeetingItemExecutive"
+msgstr ""
+
 #. Default: "MeetingItemNEGO"
 msgid "MeetingItemNEGO"
 msgstr ""
@@ -148,6 +152,10 @@ msgstr ""
 
 #. Default: "Meeting Item Recurring EM"
 msgid "MeetingItemRecurringEM"
+msgstr ""
+
+#. Default: "MeetingItemRecurringExecutive"
+msgid "MeetingItemRecurringExecutive"
 msgstr ""
 
 #. Default: "MeetingItemRecurringNEGO"
@@ -252,6 +260,10 @@ msgstr ""
 
 #. Default: "Meeting Item Template EM"
 msgid "MeetingItemTemplateEM"
+msgstr ""
+
+#. Default: "MeetingItemTemplateExecutive"
+msgid "MeetingItemTemplateExecutive"
 msgstr ""
 
 #. Default: "MeetingItemTemplateNEGO"

--- a/src/Products/MeetingCommunes/locales/fr/LC_MESSAGES/plone.po
+++ b/src/Products/MeetingCommunes/locales/fr/LC_MESSAGES/plone.po
@@ -58,6 +58,10 @@ msgstr "Séance du Conseil Communal"
 msgid "MeetingEM"
 msgstr "Séance de l'Etat-Major"
 
+#. Default: "MeetingExecutive"
+msgid "MeetingExecutive"
+msgstr "Séance Bureau exécutif"
+
 #. Default: "Meeting Item AG"
 msgid "MeetingItemAG"
 msgstr "Point AG"

--- a/src/Products/MeetingCommunes/locales/fr/LC_MESSAGES/plone.po
+++ b/src/Products/MeetingCommunes/locales/fr/LC_MESSAGES/plone.po
@@ -102,6 +102,10 @@ msgstr "Point Conseil Communal"
 msgid "MeetingItemEM"
 msgstr "Point Etat-Major"
 
+#. Default: "MeetingItemExecutive"
+msgid "MeetingItemExecutive"
+msgstr "Point Bureau exécutif"
+
 #. Default: "MeetingItemNEGO"
 msgid "MeetingItemNEGO"
 msgstr "Point Comité de concertation et négociation "
@@ -149,6 +153,10 @@ msgstr "Point récurrent Conseil Communal"
 #. Default: "Meeting Item Recurring EM"
 msgid "MeetingItemRecurringEM"
 msgstr "Point récurrent Etat-Major"
+
+#. Default: "MeetingItemRecurringExecutive"
+msgid "MeetingItemRecurringExecutive"
+msgstr "Point récurrent Bureau exécutif"
 
 #. Default: "MeetingItemRecurringNEGO"
 msgid "MeetingItemRecurringNEGO"
@@ -253,6 +261,10 @@ msgstr "Modèle de point Conseil Communal"
 #. Default: "Meeting Item Template EM"
 msgid "MeetingItemTemplateEM"
 msgstr "Modèle de point Etat-Major"
+
+#. Default: "MeetingItemTemplateExecutive"
+msgid "MeetingItemTemplateExecutive"
+msgstr "Modèle de point Bureau exécutif"
 
 #. Default: "MeetingItemTemplateNEGO"
 msgid "MeetingItemTemplateNEGO"

--- a/src/Products/MeetingCommunes/locales/nl/LC_MESSAGES/plone.po
+++ b/src/Products/MeetingCommunes/locales/nl/LC_MESSAGES/plone.po
@@ -101,6 +101,10 @@ msgstr "Item gemeenteraadsvergadering"
 msgid "MeetingItemEM"
 msgstr ""
 
+#. Default: "MeetingItemExecutive"
+msgid "MeetingItemExecutive"
+msgstr ""
+
 #. Default: "MeetingItemNEGO"
 msgid "MeetingItemNEGO"
 msgstr ""
@@ -147,6 +151,10 @@ msgstr ""
 
 #. Default: "Meeting Item Recurring EM"
 msgid "MeetingItemRecurringEM"
+msgstr ""
+
+#. Default: "MeetingItemRecurringExecutive"
+msgid "MeetingItemRecurringExecutive"
 msgstr ""
 
 #. Default: "MeetingItemRecurringNEGO"
@@ -251,6 +259,10 @@ msgstr ""
 
 #. Default: "Meeting Item Template EM"
 msgid "MeetingItemTemplateEM"
+msgstr ""
+
+#. Default: "MeetingItemTemplateExecutive"
+msgid "MeetingItemTemplateExecutive"
 msgstr ""
 
 #. Default: "MeetingItemTemplateNEGO"

--- a/src/Products/MeetingCommunes/locales/nl/LC_MESSAGES/plone.po
+++ b/src/Products/MeetingCommunes/locales/nl/LC_MESSAGES/plone.po
@@ -57,6 +57,10 @@ msgstr "Gemeenteraadsvergadering"
 msgid "MeetingEM"
 msgstr ""
 
+#. Default: "MeetingExecutive"
+msgid "MeetingExecutive"
+msgstr ""
+
 #. Default: "Meeting Item AG"
 msgid "MeetingItemAG"
 msgstr ""

--- a/src/Products/MeetingCommunes/locales/plone.pot
+++ b/src/Products/MeetingCommunes/locales/plone.pot
@@ -435,12 +435,24 @@ msgstr ""
 msgid "MeetingItemexecutive"
 msgstr ""
 
+#. Default: "MeetingItemExecutive"
+msgid "MeetingItemExecutive"
+msgstr ""
+
 #. Default: "MeetingItemTemplateexecutive"
 msgid "MeetingItemTemplateexecutive"
 msgstr ""
 
+#. Default: "MeetingItemTemplateExecutive"
+msgid "MeetingItemTemplateExecutive"
+msgstr ""
+
 #. Default: "MeetingItemRecurringexecutive"
 msgid "MeetingItemRecurringexecutive"
+msgstr ""
+
+#. Default: "MeetingItemRecurringExecutive"
+msgid "MeetingItemRecurringExecutive"
 msgstr ""
 
 #. Default: "Meetingvolonteers"

--- a/src/Products/MeetingCommunes/locales/plone.pot
+++ b/src/Products/MeetingCommunes/locales/plone.pot
@@ -427,6 +427,10 @@ msgstr ""
 msgid "Meetingexecutive"
 msgstr ""
 
+#. Default: "MeetingExecutive"
+msgid "MeetingExecutive"
+msgstr ""
+
 #. Default: "MeetingItemexecutive"
 msgid "MeetingItemexecutive"
 msgstr ""


### PR DESCRIPTION
I added the translation of MeetingExecutive because it wasn't present in Camelcase.