### PR TITLE
Make `CustomMeetingConfig.getUsedFinanceGroupIds` work with item sent to another MC with inheritated advices.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,9 @@ The Products.MeetingCommunes version must be the same as the Products.PloneMeeti
   [gbastien]
 - Fixed POD template `avis-df.odt` in `examples_fr` profile.
   [gbastien]
+- Make `CustomMeetingConfig.getUsedFinanceGroupIds` work with item sent to
+  another MC with inheritated advices.
+  [gbastien]
 
 4.2b24 (2022-09-29)
 -------------------

--- a/src/Products/MeetingCommunes/tests/testCustomMeetingItem.py
+++ b/src/Products/MeetingCommunes/tests/testCustomMeetingItem.py
@@ -15,6 +15,8 @@ class testCustomMeetingItem(MeetingCommunesTestCase):
            that will return adviser ids used on the FINANCE_ADVICES_COLLECTION_ID
            collection, this is used in the adapted method 'showFinanceAdviceTemplate'.'''
         cfg = self.meetingConfig
+        cfg2 = self.meetingConfig2
+        cfg2Id = cfg2.getId()
         collection = getattr(cfg.searches.searches_items, FINANCE_ADVICES_COLLECTION_ID)
         # make sure collection is active
         if not collection.enabled:
@@ -54,6 +56,29 @@ class testCustomMeetingItem(MeetingCommunesTestCase):
              'delay_label': 'Not a finance advice',
              'is_linked_to_previous_row': '0'}, ]
         )
+        cfg2.setCustomAdvisers([
+            {'row_id': 'unique_id_001_2',
+             'org': self.developers_uid,
+             'for_item_created_from': today,
+             'delay': '10',
+             'delay_left_alert': '4',
+             'delay_label': 'Finance advice 1',
+             'is_linked_to_previous_row': '0'},
+            {'row_id': 'unique_id_002_2',
+             'org': self.developers_uid,
+             'for_item_created_from': today,
+             'delay': '20',
+             'delay_left_alert': '4',
+             'delay_label': 'Finance advice 2',
+             'is_linked_to_previous_row': '1'},
+            {'row_id': 'unique_id_003_2',
+             'org': self.developers_uid,
+             'for_item_created_from': today,
+             'delay': '20',
+             'delay_left_alert': '4',
+             'delay_label': 'Not a finance advice',
+             'is_linked_to_previous_row': '0'}, ]
+        )
         # create an item without finance advice
         self.changeUser('pmManager')
         item = self.create('MeetingItem')
@@ -86,8 +111,25 @@ class testCustomMeetingItem(MeetingCommunesTestCase):
         # finally ask a real finance advice, this time it will work
         item.setOptionalAdvisers(('{0}__rowid__unique_id_001'.format(self.developers_uid), ))
         item._update_after_edit()
-        self.assertEqual(cfg.adapted().getUsedFinanceGroupIds(item), [self.developers_uid])
+        self.assertEqual(cfg.adapted().getUsedFinanceGroupIds(item),
+                         [self.developers_uid])
         self.assertTrue(item.adapted().showFinanceAdviceTemplate())
+
+        # when using inheritated advice, it works as well
+        clonedItem = item.clone(setCurrentAsPredecessor=True, inheritAdvices=True)
+        self.assertEqual(cfg.adapted().getUsedFinanceGroupIds(clonedItem),
+                         [self.developers_uid])
+        self.assertTrue(clonedItem.adapted().showFinanceAdviceTemplate())
+
+        # and also when item sent to other MC and advice inheritated
+        cfg.setItemManualSentToOtherMCStates(('itemcreated', ))
+        cfg.setContentsKeptOnSentToOtherMC((u'advices', ))
+        clonedItem.setOtherMeetingConfigsClonableTo((cfg2Id, ))
+        item._update_after_edit()
+        clonedItem2 = clonedItem.cloneToOtherMeetingConfig(cfg2Id)
+        self.assertEqual(cfg2.adapted().getUsedFinanceGroupIds(clonedItem2),
+                         [self.developers_uid])
+        self.assertTrue(clonedItem2.adapted().showFinanceAdviceTemplate())
 
         # if the collection does not exist, [] is returned
         self.deleteAsManager(collection.UID())


### PR DESCRIPTION
See #PM-3992
