### PR TITLE
Adapted code regarding removal of `MeetingConfig.useGroupsAsCategories`.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,8 @@ The Products.MeetingCommunes version must be the same as the Products.PloneMeeti
   `CompoundCriterion` adapter `items-with-advice-back-to-item-validation-states`
   to get items having finances advice that are return in item validation states.
   [gbastien]
+- Adapted code regarding removal of `MeetingConfig.useGroupsAsCategories`.
+  [gbastien]
 
 4.2b24 (2022-09-29)
 -------------------

--- a/src/Products/MeetingCommunes/browser/overrides.py
+++ b/src/Products/MeetingCommunes/browser/overrides.py
@@ -456,7 +456,7 @@ class MCItemDocumentGenerationHelperView(ItemDocumentGenerationHelperView):
         tool = api.portal.get_tool('portal_plonemeeting')
         cfg = tool.getMeetingConfig(self.context)
         # proposingGroup
-        if cfg.getUseGroupsAsCategories():
+        if 'category' not in cfg.getUsedItemAttributes():
             catalog_index = 'getProposingGroup'
             context_category = self.real_context.getProposingGroup()
         else:

--- a/src/Products/MeetingCommunes/profiles/examples_fr/import_data.py
+++ b/src/Products/MeetingCommunes/profiles/examples_fr/import_data.py
@@ -763,6 +763,7 @@ councilMeeting.annexTypes = [annexe, annexeBudget, annexeCahier,
                              annexeAvis, annexeAvisLegal,
                              annexeSeance]
 councilMeeting.usedItemAttributes = ['description',
+                                     'category',
                                      'proposingGroupWithGroupInCharge',
                                      'motivation',
                                      'oralQuestion',
@@ -786,9 +787,6 @@ councilMeeting.usedMeetingAttributes = ['start_date',
                                         'observations',
                                         'notes',
                                         'in_and_out_moves']
-
-councilMeeting.useGroupsAsCategories = False
-
 councilMeeting.itemColumns = ['Creator', 'CreationDate', 'ModificationDate', 'review_state', 'getCategory',
                               'proposing_group_acronym', 'groups_in_charge_acronym', 'advices', 'meeting_date',
                               'actions']

--- a/src/Products/MeetingCommunes/tests/testCustomViews.py
+++ b/src/Products/MeetingCommunes/tests/testCustomViews.py
@@ -677,7 +677,7 @@ class testCustomViews(MeetingCommunesTestCase):
     def test__filter_items(self):
         cfg = self.meetingConfig
         self.changeUser('pmManager')
-        cfg.setUseGroupsAsCategories(False)
+        self._enableField('category')
         cfg.setInsertingMethodsOnAddItem(
             ({'insertingMethod': 'on_categories', 'reverse': '0'},))
         m = self._createMeetingWithItems()
@@ -846,7 +846,7 @@ class testCustomViews(MeetingCommunesTestCase):
     def test_get_grouped_items(self):
         self.changeUser('pmManager')
         cfg = self.meetingConfig
-        cfg.setUseGroupsAsCategories(False)
+        self._enableField('category')
         cfg.setInsertingMethodsOnAddItem(
             ({'insertingMethod': 'on_categories', 'reverse': '0'},))
         m = self._createMeetingWithItems()
@@ -1076,7 +1076,7 @@ class testCustomViews(MeetingCommunesTestCase):
     def test_get_multiple_level_printing(self):
         self.changeUser('pmManager')
         cfg = self.meetingConfig
-        cfg.setUseGroupsAsCategories(False)
+        self._enableField('category')
         cfg.setInsertingMethodsOnAddItem(
             ({'insertingMethod': 'on_categories', 'reverse': '0'},))
         m = self._createMeetingWithItems()
@@ -1130,7 +1130,7 @@ class testCustomViews(MeetingCommunesTestCase):
 
     def test_print_item_number_within_category(self):
         cfg = self.meetingConfig
-        cfg.setUseGroupsAsCategories(True)
+        self._enableField('category', enable=False)
 
         def create_and_validate_item(creator, preferred_meeting=None):
             self.changeUser(creator)


### PR DESCRIPTION
See #PM-1008